### PR TITLE
spec file cleanup

### DIFF
--- a/openstack-app-catalog-ui.spec
+++ b/openstack-app-catalog-ui.spec
@@ -11,36 +11,15 @@ BuildArch:     noarch
 
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
-BuildRequires: python-lockfile
 BuildRequires: python-pbr
-BuildRequires: python-sphinx >= 1.1.3
 BuildRequires: python-flake8
 BuildRequires: openstack-dashboard
-BuildRequires: tree
-
-# testing deps, not on RHEl
-%if 0%{?rhel} == 0
-BuildRequires: python-coverage
-BuildRequires: python-django-nose
-BuildRequires: python-mock
-BuildRequires: python-mox
-BuildRequires: python-nose
-BuildRequires: python-nose-exclude
-BuildRequires: python-nose-xcover
-BuildRequires: python-openstack-nose-plugin
-BuildRequires: python-selenium
-%endif
 
 Requires: pytz
 Requires: openstack-dashboard
-Requires: python-lockfile
 Requires: python-scss
-Requires: python-netaddr
 Requires: python-pbr
-Requires: python-eventlet
-Requires: python-iso8601
 Requires: python-oslo-config
-Requires: python-lockfile
 
 
 %description
@@ -81,16 +60,11 @@ cp -r app_catalog/templates/* %{buildroot}%{python2_sitelib}/app_catalog/templat
 cp -r component_catalog/templates/* %{buildroot}%{python2_sitelib}/component_catalog/templates/
 
 %check
-# don't run tests on rhel
-%if 0%{?rhel} == 0
-# until django-1.6 support for tests is enabled, disable tests
-export PYTHONPATH=$PYTHONPATH:%{_datadir}/openstack-dashboard
-# TODO : reenable, We don't have selenium
-#./run_tests.sh -N -P
-%endif
+# no upstream tests
 
 %files
 %doc README.rst
+%license LICENSE
 %dir %{python2_sitelib}/app_catalog
 %dir %{python2_sitelib}/component_catalog
 %{python2_sitelib}/*.egg-info


### PR DESCRIPTION
app-catalog-ui does not provide docs, nor does it provide tests. We can skip all that in spec. Additionally, app-catalog-ui should rely on openstack-dashboard dependencies.
